### PR TITLE
fix(js): correctly assigning key to Review components

### DIFF
--- a/src/components/Review.jsx
+++ b/src/components/Review.jsx
@@ -10,7 +10,7 @@ const Review = ({ review }) => {
 	const { idReview, idFilm, rating, comment, user: author } = review;
 
 	return (
-		<div>
+		<>
 			<ListItem alignItems="flex-start">
 				<ListItemAvatar>
 					<Avatar
@@ -39,7 +39,7 @@ const Review = ({ review }) => {
 				/>
 			</ListItem>
 			<Divider variant="inset" component="li" />
-		</div>
+		</>
 	);
 };
 

--- a/src/routes/MoviePage.jsx
+++ b/src/routes/MoviePage.jsx
@@ -69,7 +69,10 @@ export function MoviePage() {
 			{/* Reviews List */}
 			<AlignItemsList>
 				{reviews.map((review) => (
-					<Review key={review.id} review={review} />
+					<Review
+						key={`movie:${idFilm}/review:${review.idReview}`}
+						review={review}
+					/>
 				))}
 			</AlignItemsList>
 


### PR DESCRIPTION
- Fixing my previous mistake about the `~~review.id~~, ***reviewe.idReview** 
- replaced a `<div>` inside Review() with a fragment